### PR TITLE
Logging to file with status and parallel recordings option

### DIFF
--- a/bbb-mp4.js
+++ b/bbb-mp4.js
@@ -26,6 +26,8 @@ var options = {
 }
 options.executablePath = "/usr/bin/google-chrome"
 
+const disableAsyncRecordings = false;
+
 const logFolder = '/usr/src/app/processed/';
 let logFile;
 
@@ -33,6 +35,11 @@ async function main() {
     let tempLogFile = logInit();
     let browser, page;
     try {
+        if (disableAsyncRecordings) {
+            console.log("Waiting other recordings to finish");
+            await waitRecordingsToFinish();
+        }
+
         xvfb.startSync()
 
         var url = process.argv[2];
@@ -161,6 +168,24 @@ function logDone(exportName) {
 function log(d) {
     logFile.write(d + '\n');
     process.stdout.write(d + '\n');
+}
+
+async function waitRecordingsToFinish() {
+    while (existsRecordings()) {
+        await new Promise(resolve => setTimeout(resolve, random(1000, 3000)));
+    }
+}
+
+function existsRecordings() {
+    // count of files in folder that indicates recordings
+    return fs.readdirSync(logFolder)
+        .filter(file => file.endsWith('.start'))
+        .length > 0;
+}
+
+// min and max included
+function random(min, max) {
+    return Math.floor(Math.random() * (max - min + 1) + min);
 }
 
 main()


### PR DESCRIPTION
## New features

### Logging to file
Creates a log file of the recording process in recordings folder. Changes the file extension depending on the recording stage.

- MEETING_ID.`start` - the recording process has started and is working
- MEETING_ID.`error` - an error occurred while recording
- MEETING_ID.`done` - recording completed successfully

Using this logging file, you can track the status of recording.

### Parallel recordings
Added flag to disable parallel recording - `disableAsyncRecordings`

You can disable parallel recording by edit this flag in `bbb-mp4.js` file (default enabled). The process will wait for the other records to finish. After that, a random record from the waiting ones will start.

This can help with load balancing when recording many mp4 files.